### PR TITLE
Enable to play on more then two pads

### DIFF
--- a/game.libretro.nestopia/resources/topology.xml
+++ b/game.libretro.nestopia/resources/topology.xml
@@ -2,22 +2,14 @@
 <logicaltopology maxplayers="4">
   <port id="1">
     <accepts controller="game.controller.nes"/>
-    <accepts controller="game.controller.nes.four.square">
-      <port id="1">
-        <accepts controller="game.controller.nes"/>
-      </port>
-      <port id="2">
-        <accepts controller="game.controller.nes"/>
-      </port>
-      <port id="3">
-        <accepts controller="game.controller.nes"/>
-      </port>
-      <port id="4">
-        <accepts controller="game.controller.nes"/>
-      </port>
-    </accepts>
   </port>
   <port id="2">
+    <accepts controller="game.controller.nes"/>
+  </port>
+  <port id="3">
+    <accepts controller="game.controller.nes"/>
+  </port>
+  <port id="4">
     <accepts controller="game.controller.nes"/>
   </port>
 </logicaltopology>


### PR DESCRIPTION
The previous configuration is not working - no possibilities to play with 4 pads. I figure it out that this modification fix the issue. Tested on latest LibreElec and RetroPlayer 20 alpha 1 (2022-02-10)